### PR TITLE
update query

### DIFF
--- a/etc/views.sql
+++ b/etc/views.sql
@@ -9,8 +9,6 @@ SELECT s.* FROM (
     ) AS s
 WHERE
     s.rownum = 1 AND s.token_type = 'xsampa';
--- FIXME: add WordCount!? distinct words per ... file?
-
 
 -- Utterance initial phones
 CREATE VIEW IF NOT EXISTS utterance_initials AS
@@ -34,5 +32,27 @@ SELECT
 FROM
     'phones.csv' AS p
 GROUP BY p.u_id;
+
+
+-- Word count per lang
+CREATE VIEW IF NOT EXISTS langstats AS                                 
+SELECT                                                             
+	w.cldf_languageReference,
+	-- word form frequency
+	count(w.cldf_id) as WordCount
+FROM
+	'words.csv' as w
+GROUP BY w.cldf_languageReference;
+
+
+-- Word form frequency
+CREATE VIEW IF NOT EXISTS wordstats AS                                 
+SELECT                                                             
+	w.cldf_languageReference,
+	-- word form frequency
+	count(w.cldf_name) as WordFreq
+FROM
+	'words.csv' as w
+GROUP BY w.cldf_languageReference, cldf_name;
 
 -- filter non-pulmonic consonants, i.e. click, ejective, implosive (other manners?)

--- a/init_query.sql
+++ b/init_query.sql
@@ -1,0 +1,61 @@
+SELECT
+    phone.*,
+    word.cldf_languageReference AS Language,
+    word.speaker_id AS Speaker,
+    utt.speech_rate AS SpeechRate,
+    utt.num_phones AS num_phones,
+    CASE
+        WHEN phone.cldf_id in (select cldf_id from utterance_initials) then 1 else 0
+        END utt_initial,
+    CASE
+        WHEN phone.cldf_id in (select cldf_id from word_initials) then 1 else 0
+        END word_initial,
+    CASE
+        WHEN sound.cldf_cltsReference like '%stop%' then 'stop' else 'dunno'
+        END sound_class,
+	-- standardize speech rate
+	-- (utt.log_speech_rate - avg(utt.log_speech_rate) over()) / stdev(utt.log_speech_rate) over() as z_speech_rate,
+    ws.WordFreq AS freq,
+	ls.WordCount AS count
+	-- ws.WordFreq/ls.WordCount AS relation
+FROM
+    "phones.csv" AS phone,
+    "words.csv" AS word,
+    ParameterTable AS sound,
+    wordstats AS ws,  -- language-level stats on words.
+	langstats AS ls
+LEFT JOIN
+    (
+        SELECT
+            -- Here we compute the threshold for exclusion of unusually long phones.
+            w.speaker_id, avg(p.duration) + 3 * stdev(p.duration) AS threshold
+        FROM
+            `phones.csv` AS p,
+            `words.csv` AS w
+        WHERE
+            p.cldf_parameterreference IS NOT NULL AND
+            p.wd_id = w.cldf_id
+        GROUP BY w.speaker_id  -- Thresholds are computed per speaker.
+    ) AS t
+ON
+    word.speaker_id = t.speaker_id
+LEFT JOIN
+    utterances AS utt  -- utterance-level stats such as speech rate.
+ON
+    phone.u_ID = utt.u_id
+WHERE
+    ws.cldf_languageReference = word.cldf_languageReference AND
+    phone.wd_id = word.cldf_id AND
+    phone.cldf_parameterReference = sound.cldf_id AND
+    -- We only consider non-long, pulmonic consonants ...
+    sound.cldf_cltsReference LIKE '%_consonant' AND
+    sound.cldf_cltsReference NOT LIKE '%click%' AND
+    sound.cldf_cltsReference NOT LIKE '%implosive%' AND
+    sound.cldf_cltsReference NOT LIKE '%ejective%' AND
+    sound.cldf_cltsReference NOT LIKE '%long%' AND
+    -- ... and exclude utterance-initial stops.
+    NOT (phone.cldf_id in (select cldf_id from utterance_initials) AND sound.cldf_cltsReference LIKE '%stop%'
+	) AND
+    -- We also exclude phonemes with unusually long durations, which hint at annotation errors.
+    phone.duration < t.threshold
+;


### PR DESCRIPTION
@xrotwang I had now time to look at the updated query you provided. Thank you again for all this work. Trying to add the standardization and the word count, I am running into two problems:

- I cannot use stdev() inside a window function - why is that? Is there anothe rcomputationally efficient way to produce the standardization?
- The word count does not work as you provided in the view. I am trying to update the view, but I am having two problems: a) conceptually, and b) computationally.

Conceptually: Do we need two views for this? To get at the frequency, I need to divide the number of occurrences of a word (w.cldf_name) by the total words in the language (w.cldf_id). However, the first one I only get by grouping my data on language and w.cldf_name, and the second by only grouping on the language. Is there a way to combine those groupings in a single view?

Computationally: The way I set up things right now (two views, dividing their results) kills my laptop, and I do not understand why. Could you take a look at it and tell me what I am doing wrong, so that I can fix it?

All this is not urgent, as you can see by the fact that I as well did not have time to look at this previously. I very much appreciate all the learning I am getting about SQL by this though.